### PR TITLE
Fix GETting multi-row values

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,8 +32,8 @@
         }
     },
     "containerEnv": {
-        "RONDB_PATH": "/usr/src/app/rondb-22.10.5-linux-glibc2.28-arm64_v8"
-        // Do this manually:
-        // export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/src/app/rondb-22.10.5-linux-glibc2.28-arm64_v8/lib
+        "RONDB_PATH": "/usr/src/app/rondb-22.10.5-linux-glibc2.28-arm64_v8",
+        // This assumes that the RonDB tarball is placed the root of the workspace folder
+        "LD_LIBRARY_PATH": "/usr/src/app/rondb-22.10.5-linux-glibc2.28-arm64_v8/lib"
     }
 }

--- a/pink/rondis/sql/STRING_key.sql
+++ b/pink/rondis/sql/STRING_key.sql
@@ -2,9 +2,8 @@ CREATE TABLE redis.string_keys(
     -- Redis actually supports a max key size of 512MiB,
     -- but we choose not to support that here
     redis_key VARBINARY(3000) NOT NULL,
-    -- We will use a ndb auto-increment
     -- This is to save space when referencing the key in the value table
-    rondb_key BIGINT UNSIGNED,
+    rondb_key BIGINT UNSIGNED AUTO_INCREMENT NULL,
     -- TODO: Replace with Enum below
     value_data_type INT UNSIGNED NOT NULL,
     -- value_data_type ENUM('string', 'number', 'binary_string'),

--- a/pink/rondis/string/commands.cc
+++ b/pink/rondis/string/commands.cc
@@ -50,8 +50,9 @@ void rondb_get_command(Ndb *ndb,
     // start copying from 3rd byte
     memcpy(&key_row.redis_key[2], key_str, key_len);
     // Length as little endian
-    key_row.redis_key[0] = key_len & 255;
-    key_row.redis_key[1] = key_len >> 8;
+    Uint8 *ptr = (Uint8 *)&key_row.redis_key[0];
+    ptr[0] = Uint8(key_len & 255);
+    ptr[1] = Uint8(key_len >> 8);
 
     // This is (usually) a local operation to calculate the correct data node, using the
     // hash of the pk value.
@@ -86,8 +87,9 @@ void rondb_get_command(Ndb *ndb,
         // start copying from 3rd byte
         memcpy(&key_row.redis_key[2], key_str, key_len);
         // Length as little endian
-        key_row.redis_key[0] = key_len & 255;
-        key_row.redis_key[1] = key_len >> 8;
+        Uint8 *ptr = (Uint8 *)&key_row.redis_key[0];
+        ptr[0] = Uint8(key_len & 255);
+        ptr[1] = Uint8(key_len >> 8);
 
         /*
             Our value uses value rows, so a more complex read is required.

--- a/pink/rondis/string/commands.cc
+++ b/pink/rondis/string/commands.cc
@@ -154,7 +154,7 @@ void rondb_set_command(
     }
 
     char varsize_param[EXTENSION_VALUE_LEN + 500];
-    Uint32 num_value_rows = value_len / EXTENSION_VALUE_LEN;
+    Uint32 num_value_rows = 0;
     Uint64 rondb_key = 0;
 
     if (value_len > INLINE_VALUE_LEN)
@@ -168,6 +168,13 @@ void rondb_set_command(
          * deleting the row in the main table ensures that all
          * value rows are also deleted.
          */
+        Uint32 extended_value_len = value_len - INLINE_VALUE_LEN;
+        num_value_rows = extended_value_len / EXTENSION_VALUE_LEN;
+        if (extended_value_len % EXTENSION_VALUE_LEN != 0)
+        {
+            num_value_rows++;
+        }
+
         if (rondb_get_rondb_key(tab, rondb_key, ndb, response) != 0)
         {
             return;

--- a/pink/rondis/string/db_operations.cc
+++ b/pink/rondis/string/db_operations.cc
@@ -601,22 +601,12 @@ int rondb_get_rondb_key(const NdbDictionary::Table *tab,
                         Ndb *ndb,
                         std::string *response)
 {
-    if (ndb->getAutoIncrementValue(tab, rondb_key, unsigned(1024)) == 0)
+    if (ndb->getAutoIncrementValue(tab, rondb_key, unsigned(1024)) != 0)
     {
-        return 0;
+        assign_ndb_err_to_response(response,
+                                   "Failed to get autoincrement value",
+                                   ndb->getNdbError());
+        return -1;
     }
-    if (ndb->getNdbError().classification == NdbError::NoDataFound)
-    {
-        printf("No data found when auto-incrementing value for table '%s'; starting from scratch\n",
-               tab->getName());
-        if (ndb->setAutoIncrementValue(tab, Uint64(1), false) == 0)
-        {
-            rondb_key = Uint64(1);
-            return 0;
-        }
-    }
-    assign_ndb_err_to_response(response,
-                               "Failed to get autoincrement value",
-                               ndb->getNdbError());
-    return -1;
+    return 0;
 }

--- a/pink/rondis/string/db_operations.cc
+++ b/pink/rondis/string/db_operations.cc
@@ -605,8 +605,10 @@ int rondb_get_rondb_key(const NdbDictionary::Table *tab,
     {
         return 0;
     }
-    if (ndb->getNdbError().code == 626)
+    if (ndb->getNdbError().classification == NdbError::NoDataFound)
     {
+        printf("No data found when auto-incrementing value for table '%s'; starting from scratch\n",
+               tab->getName());
         if (ndb->setAutoIncrementValue(tab, Uint64(1), false) == 0)
         {
             rondb_key = Uint64(1);

--- a/pink/rondis/string/db_operations.cc
+++ b/pink/rondis/string/db_operations.cc
@@ -304,7 +304,6 @@ int create_value_row(std::string *response,
     buf[1] = this_value_len >> 8;
     op->setValue(VALUE_TABLE_COL_value, buf);
     {
-        int ret_code = op->getNdbError().code;
         if (op->getNdbError().code != 0)
         {
             assign_ndb_err_to_response(response, FAILED_DEFINE_OP, op->getNdbError());
@@ -465,7 +464,8 @@ int get_value_rows(std::string *response,
         bool is_last_row = (row_index == (num_rows - 1));
         NdbTransaction::ExecType commit_type = is_last_row ? NdbTransaction::Commit : NdbTransaction::NoCommit;
         if (trans->execute(commit_type,
-                           NdbOperation::AbortOnError) != 0)
+                           NdbOperation::AbortOnError) != 0 ||
+            trans->getNdbError().code != 0)
         {
             assign_ndb_err_to_response(response,
                                        FAILED_READ_KEY,
@@ -516,7 +516,8 @@ int get_complex_key_row(std::string *response,
         return RONDB_INTERNAL_ERROR;
     }
     if (trans->execute(NdbTransaction::NoCommit,
-                       NdbOperation::AbortOnError) != 0)
+                       NdbOperation::AbortOnError) != 0 ||
+        trans->getNdbError().code != 0)
     {
         assign_ndb_err_to_response(response,
                                    FAILED_READ_KEY,

--- a/pink/rondis/string/db_operations.h
+++ b/pink/rondis/string/db_operations.h
@@ -5,6 +5,8 @@
 #include <ndbapi/NdbApi.hpp>
 #include <ndbapi/Ndb.hpp>
 
+const Uint32 ROWS_PER_READ = 2;
+
 int create_key_row(std::string *response,
                    Ndb *ndb,
                    const NdbDictionary::Table *tab,
@@ -108,6 +110,13 @@ int get_value_rows(std::string *response,
                    const Uint32 num_rows,
                    const Uint64 key_id,
                    const Uint32 tot_value_len);
+
+int read_batched_value_rows(std::string *response,
+                            NdbTransaction *trans,
+                            const Uint64 rondb_key,
+                            const Uint32 num_rows_to_read,
+                            const Uint32 start_ordinal,
+                            const NdbTransaction::ExecType commit_type);
 
 int rondb_get_rondb_key(const NdbDictionary::Table *tab,
                         Uint64 &key_id,

--- a/pink/rondis/string/table_definitions.h
+++ b/pink/rondis/string/table_definitions.h
@@ -69,7 +69,7 @@ struct value_table
 {
     Uint64 rondb_key;
     Uint32 ordinal;
-    char value[EXTENSION_VALUE_LEN];
+    char value[EXTENSION_VALUE_LEN + 2];
 };
 
 /*

--- a/pink/rondis/tests/get_set.sh
+++ b/pink/rondis/tests/get_set.sh
@@ -60,8 +60,9 @@ set_and_get "$KEY:medium" "$medium_value"
 # Too large values seem to fail due to the network buffer size
 # Minimal amount to create value rows: 30000
 
-echo "Testing large string (30,000 characters)..."
-large_value=$(head -c 30000 < /dev/zero | tr '\0' 'a')
+# TODO: Increase this as soon as GH actions allows it
+echo "Testing large string (10,000 characters)..."
+large_value=$(head -c 10000 < /dev/zero | tr '\0' 'a')
 set_and_get "$KEY:large" "$large_value"
 
 # echo "Testing xl string (100,000 characters)..."

--- a/pink/rondis/tests/get_set.sh
+++ b/pink/rondis/tests/get_set.sh
@@ -60,9 +60,8 @@ set_and_get "$KEY:medium" "$medium_value"
 # Too large values seem to fail due to the network buffer size
 # Minimal amount to create value rows: 30000
 
-# TODO: Increase this as soon as GH actions allows it
-echo "Testing large string (10,000 characters)..."
-large_value=$(head -c 10000 < /dev/zero | tr '\0' 'a')
+echo "Testing large string (30,000 characters)..."
+large_value=$(head -c 30000 < /dev/zero | tr '\0' 'a')
 set_and_get "$KEY:large" "$large_value"
 
 # echo "Testing xl string (100,000 characters)..."

--- a/pink/rondis/tests/get_set.sh
+++ b/pink/rondis/tests/get_set.sh
@@ -50,7 +50,7 @@ generate_random_chars() {
   local random_string=""
 
   while [ "${#random_string}" -lt "$length" ]; do
-    random_string+=$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c "$length")
+    random_string+=$(head /dev/urandom | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | head -c "$length")
   done
 
   echo "${random_string:0:$length}"

--- a/pink/rondis/tests/get_set.sh
+++ b/pink/rondis/tests/get_set.sh
@@ -34,7 +34,7 @@ EOF
     if [[ "$result" == "$value" ]]; then
         echo "PASS: $key with value length ${#value}"
     else
-        echo "FAIL: $key with value length ${#value}"
+        echo "FAIL: $key with value length ${#value}; got length ${#result}"
         echo "Expected: $value"
         echo "Got: $result"
         exit 1

--- a/pink/rondis/tests/get_set.sh
+++ b/pink/rondis/tests/get_set.sh
@@ -29,14 +29,17 @@ EOF
     
     # GET the value
     local result=$(redis-cli GET "$key")
+
+    local expected_hash=$(echo -n "$value" | sha256sum | awk '{print $1}')
+    local actual_hash=$(echo -n "$result" | sha256sum | awk '{print $1}')
     
     # Check if the retrieved value matches the expected value
-    if [[ "$result" == "$value" ]]; then
+    if [[ "$expected_hash" == "$actual_hash" ]]; then
         echo "PASS: $key with value length ${#value}"
     else
         echo "FAIL: $key with value length ${#value}; got length ${#result}"
-        echo "Expected: $value"
-        echo "Got: $result"
+        echo "Expected hash:    $expected_hash"
+        echo "Received hash:    $actual_hash"
         exit 1
     fi
     echo

--- a/pink/rondis/tests/get_set.sh
+++ b/pink/rondis/tests/get_set.sh
@@ -69,7 +69,7 @@ set_and_get "$KEY:small" "hello"
 # TODO: Increase this as soon as GH actions allows it:
 # for NUM_CHARS in 100 10000 30000 50000 80000 100000; do
 
-for NUM_CHARS in 100 10000; do
+for NUM_CHARS in 100 10000 30000; do
     echo "Testing string with $NUM_CHARS characters..."
     test_value=$(generate_random_chars $NUM_CHARS)
     set_and_get "$KEY:$NUM_CHARS" "$test_value"

--- a/pink/rondis/tests/get_set.sh
+++ b/pink/rondis/tests/get_set.sh
@@ -67,7 +67,6 @@ set_and_get "$KEY:empty" ""
 echo "Testing small string..."
 set_and_get "$KEY:small" "hello"
 
-# Too large values seem to fail due to the network buffer size
 # Minimal amount to create value rows: 30000
 for NUM_CHARS in 100 10000 30000 50000 57000 60000 70000; do
     echo "Testing string with $NUM_CHARS characters..."

--- a/pink/rondis/tests/get_set.sh
+++ b/pink/rondis/tests/get_set.sh
@@ -69,10 +69,7 @@ set_and_get "$KEY:small" "hello"
 
 # Too large values seem to fail due to the network buffer size
 # Minimal amount to create value rows: 30000
-# TODO: Increase this as soon as GH actions allows it:
-# for NUM_CHARS in 100 10000 30000 50000 80000 100000; do
-
-for NUM_CHARS in 100 10000 30000; do
+for NUM_CHARS in 100 10000 30000 50000 57000 60000 70000; do
     echo "Testing string with $NUM_CHARS characters..."
     test_value=$(generate_random_chars $NUM_CHARS)
     set_and_get "$KEY:$NUM_CHARS" "$test_value"


### PR DESCRIPTION
* Always check errors using getNdbError()
* Compare hashes in bash tests instead of full values
FIXES:
* Multi-value-row fetching: use different memory for each row
* Multi-value-row fetching: use clean struct for every fetch (place fetch into separate func)
* Calculate number of value rows correctly in SET
* Using uint8 for type safety when read/writing value lengths from buffers
* Usage of auto-increment for rondb_key; use SQL's `AUTO_INCREMENT`
